### PR TITLE
Hi - We've fixed a wrong condition that prevented the custom subscription fields to be sent to freshmail

### DIFF
--- a/lib/citrus_mail/list.rb
+++ b/lib/citrus_mail/list.rb
@@ -14,7 +14,7 @@ module CitrusMail
     def add_subscriber(email, name=nil, custom_fields={}, options={:confirm_email => true})
       params = {:freshmail_email => email}
       params[:freshmail_name] = name if name
-      params[:freshmail_custom_field] = custom_fields if custom_fields.empty?
+      params[:freshmail_custom_field] = custom_fields unless custom_fields.empty?
       unless options[:confirm_email].nil?
         params[:confirm_email] = options[:confirm_email]
       end


### PR DESCRIPTION
this is a one-liner fix in List#add_subscriber
